### PR TITLE
Simplify the AggregateAcrossCellsResults interface.

### DIFF
--- a/js/aggregateAcrossCells.js
+++ b/js/aggregateAcrossCells.js
@@ -31,65 +31,41 @@ export class AggregateAcrossCellsResults {
     }
 
     /**
+     * @param {?number} group - Index of the group.
+     * If a number, it should be non-negative and less than {@linkcode AggregateAcrossCellsResults#numberOfGroups numberOfGroups}.
+     * This may also be `null` to obtain values for all groups.
      * @param {object} [options={}] - Optional parameters.
-     * @param {boolean} [options.asMatrix=false] - Whether to return a {@linkplain NumericMatrix} object.
-     * @param {(string|boolean)} [options.copy="view"] - Copying mode to use when `asMatrix = false`, see {@linkcode possibleCopy} for details.
-     *
-     * @return {Float64Array|Float64WasmArray|NumericMatrix}
-     * If `asMatrix = true`, a {@linkplain NumericMatrix} is returned where rows are genes, columns are groups, and values are the summed value for that gene in that group.
-     * If {@linkcode aggregateAcrossCells} was run with `average = true`, the matrix contains the mean value instead of the sum.
-     *
-     * If `asMatrix = false`, a Float64Array or Float64WasmArray (depending on `copy`) is returned, containing the matrix contents as a vector in column-major form.
-     */
-    allSums({ asMatrix = true, copy = "view" } = {}) {
-        if (!asMatrix) {
-            return utils.possibleCopy(this.#results.all_sums(), copy);
-        } else {
-            return gc.call(() => this.#results.sums_as_matrix(), ScranMatrix);
-        }
-    }
-
-    /**
-     * @param {number} group - Index of the group.
-     * This should be non-negative and less than {@linkcode AggregateAcrossCellsResults#numberOfGroups numberOfGroups}.
+     * @param {(string|boolean)} [options.copy=true] - Copying mode to use when `asMatrix = false`, see {@linkcode possibleCopy} for details.
      *
      * @return {Float64Array|Float64WasmArray}
-     * Array where each entry corresponds to a gene and contains the summed value across all cells in the specified `group`.
+     * If `group` is a number, an array is returned where each entry corresponds to a gene and contains the summed value across all cells in the specified `group`.
      * If {@linkcode aggregateAcrossCells} was run with `average = true`, the array contains the mean value instead of the sum.
-     */
-    groupSums(group, { copy = "view" } = {}) {
-        return utils.possibleCopy(this.#results.group_sums(group), copy);
-    }
-
-    /**
-     * @param {object} [options={}] - Optional parameters.
-     * @param {boolean} [options.asMatrix=false] - Whether to return a {@linkplain NumericMatrix} object.
-     * @param {(string|boolean)} [options.copy="view"] - Copying mode to use when `asMatrix = false`, see {@linkcode possibleCopy} for details.
      *
-     * @return {Float64Array|Float64WasmArray|NumericMatrix}
-     * If `asMatrix = true`, a {@linkplain NumericMatrix} is returned where rows are genes, columns are groups, and values are the number of detected cells for that gene in that group.
-     * If {@linkcode aggregateAcrossCells} was run with `average = true`, each value is the proportion of cells with detected expression.
-     *
-     * If `asMatrix = false`, a Float64Array or Float64WasmArray (depending on `copy`) is returned, containing the matrix contents as a vector in column-major form.
+     * If `group = null`, an array is returned containing the concatenation of the arrays for all groups.
+     * If `copy = "view"`, the output can be used in {@linkcode ScranMatrix#create ScranMatrix.create} to create a {@linkcode ScranMatrix} for input into other functions.
      */
-    allDetected({ asMatrix = true, copy = "view" } = {}) {
-        if (!asMatrix) {
-            return utils.possibleCopy(this.#results.all_detected(), copy);
-        } else {
-            return gc.call(() => this.#results.detected_as_matrix(), ScranMatrix);
-        }
+    sums(group, { copy = true } = {}) {
+        let vec = (group !== null ? this.#results.group_sums(group) : this.#results.all_sums());
+        return utils.possibleCopy(vec, copy);
     }
 
     /**
      * @param {number} group - Index of the group.
      * This should be non-negative and less than {@linkcode AggregateAcrossCellsResults#numberOfGroups numberOfGroups}.
+     * This may also be `null` to obtain values for all groups.
+     * @param {object} [options={}] - Optional parameters.
+     * @param {(string|boolean)} [options.copy=true] - Copying mode to use when `asMatrix = false`, see {@linkcode possibleCopy} for details.
      *
      * @return {Float64Array|Float64WasmArray}
-     * Array where each entry corresponds to a gene and contains the number of detected cells in the specified `group`.
+     * If `group` is a number, an array is returned where each entry corresponds to a gene and contains the number of detected cells in the specified `group`.
      * If {@linkcode aggregateAcrossCells} was run with `average = true`, each value is the proportion of cells with detected expression.
+     * 
+     * If `group = null`, an array is returned containing the concatenation of the arrays for all groups.
+     * If `copy = "view"`, the output can be used in {@linkcode ScranMatrix#create ScranMatrix.create} to create a {@linkcode ScranMatrix} for input into other functions.
      */
-    groupDetected(group, { copy = "view" } = {}) {
-        return utils.possibleCopy(this.#results.group_detected(group), copy);
+    detected(group, { copy = true } = {}) {
+        let vec = (group !== null ? this.#results.group_detected(group) : this.#results.all_detected());
+        return utils.possibleCopy(vec, copy);
     }
 
     /**

--- a/src/NumericMatrix.h
+++ b/src/NumericMatrix.h
@@ -52,7 +52,7 @@ struct NumericMatrix {
      * @param nc Number of columns.
      * @param values Offset to the start of an input array of `double`s of length `nr*nc`.
      */
-    NumericMatrix(int nr, int nc, uintptr_t values);
+    NumericMatrix(int nr, int nc, uintptr_t values, bool, bool);
 
     /** 
      * @return Number of rows in the matrix.

--- a/src/aggregate_across_cells.cpp
+++ b/src/aggregate_across_cells.cpp
@@ -29,20 +29,12 @@ struct AggregateAcrossCells_Results {
         return emscripten::val(emscripten::typed_memory_view(ngenes, sums.data() + i * ngenes));
     }
 
-    NumericMatrix sums_as_matrix() const {
-        return NumericMatrix(new tatami::DenseColumnMatrix<double, int, tatami::ArrayView<double> >(ngenes, ngroups, tatami::ArrayView(sums.data(), sums.size())));
-    }
-
     emscripten::val all_detected() const {
         return emscripten::val(emscripten::typed_memory_view(detected.size(), detected.data()));
     }
 
     emscripten::val group_detected(int i) const {
         return emscripten::val(emscripten::typed_memory_view(ngenes, detected.data() + i * ngenes));
-    }
-
-    NumericMatrix detected_as_matrix() const {
-        return NumericMatrix(new tatami::DenseColumnMatrix<double, int, tatami::ArrayView<double> >(ngenes, ngroups, tatami::ArrayView(detected.data(), detected.size())));
     }
 };
 
@@ -97,10 +89,8 @@ EMSCRIPTEN_BINDINGS(aggregate_across_cells) {
     emscripten::class_<AggregateAcrossCells_Results>("AggregateAcrossCells_Results")
         .function("group_sums", &AggregateAcrossCells_Results::group_sums)
         .function("all_sums", &AggregateAcrossCells_Results::all_sums)
-        .function("sums_as_matrix", &AggregateAcrossCells_Results::sums_as_matrix)
         .function("group_detected", &AggregateAcrossCells_Results::group_detected)
         .function("all_detected", &AggregateAcrossCells_Results::all_detected)
-        .function("detected_as_matrix", &AggregateAcrossCells_Results::detected_as_matrix)
         .function("num_genes", &AggregateAcrossCells_Results::num_genes)
         .function("num_groups", &AggregateAcrossCells_Results::num_groups)
         ;

--- a/tests/aggregateAcrossCells.test.js
+++ b/tests/aggregateAcrossCells.test.js
@@ -21,9 +21,13 @@ test("aggregation works as expected", () => {
     expect(res.numberOfGroups()).toBe(3);
     expect(res.numberOfGenes()).toBe(ngenes);
 
+    let agmat = scran.ScranMatrix.createDenseMatrix(res.numberOfGenes(), res.numberOfGroups(), res.sums(null, { copy: "view" }));
+    expect(agmat.numberOfColumns()).toBe(3);
+    expect(agmat.numberOfRows()).toBe(ngenes);
+
     // Comparing to the reference.
     for (var g = 0; g < 3; g++) {
-        let obs = res.groupSums(g);
+        let obs = res.sums(g);
         expect(obs.length).toEqual(ngenes);
 
         let ref = new Float64Array(ngenes);
@@ -38,16 +42,12 @@ test("aggregation works as expected", () => {
             }
         }
 
-        expect(obs.array()).toEqual(ref);
+        expect(obs).toEqual(ref);
+        expect(agmat.column(g)).toEqual(ref);
     }
-
-    let agmat = res.allSums();
-    expect(agmat.numberOfColumns()).toBe(3);
-    expect(agmat.numberOfRows()).toBe(ngenes);
-    expect(agmat.column(2)).toEqual(res.groupSums(2). slice());
     agmat.free();
 
-    expect(res.allDetected({ asMatrix: false }).length).toEqual(ngenes * 3);
+    expect(res.detected(null).length).toEqual(ngenes * 3);
 
     // Works with averages.
     {
@@ -59,13 +59,12 @@ test("aggregation works as expected", () => {
         }
 
         for (var g = 0; g < 3; g++) {
-            let obs = res.groupSums(g).slice();
+            let obs = res.sums(g).slice();
             for (var j = 0; j < ngenes; j++) {
                 obs[j] /= groupsize[g];
             }
 
-            let ref = ares.groupSums(g);
-            expect(ref.array()).toEqual(obs);
+            expect(ares.sums(g)).toEqual(obs);
         }
 
         ares.free();


### PR DESCRIPTION
Rather than passing back a ScranMatrix, we return the concatenated array across all groups, and advanced users can use this to construct their own ScranMatrix via the new createDenseMatrix function. This is a more general solution that avoids us having to write a ScranMatrix converter for every dense output; it is also more obvious to the user that the ScranMatrix needs to have its memory lifetime carefully managed if it holds a reference to the same buffer as the AggregateResults object.