### PR TITLE
Improve the predictability of the levels from convertToFactor.

### DIFF
--- a/js/factorize.js
+++ b/js/factorize.js
@@ -15,7 +15,10 @@ import * as utils from "./utils.js";
  * Only used if `buffer` is not supplied.
  * @param {?(Int32WasmArray|Int32Array)} [options.buffer=null] - Array in which the output is to be stored.
  * If provided, this should be of length equal to that of `x`.
- * @param {string} [options.action="warn"] - Action to take when invalid values (i.e., null, NaNs) are detected in `x`.
+ * @param {?Array} [options.levels=null] - An existing array of known levels to be matched against `x`.
+ * Values in `x` that are not in `levels` are considered to be invalid.
+ * If `null`, the levels are automatically inferred from `x`; these will be sorted if all-numeric or all-string.
+ * @param {string} [options.action="error"] - Action to take when invalid values (i.e., null, NaNs) are detected in `x`.
  *
  * - `"none"`: the index is silently set to `placeholder`.
  * - `"warn"`: a warning is raised on the first occurrence of an invalid value, and the index is set to `placeholder`.
@@ -27,11 +30,11 @@ import * as utils from "./utils.js";
  *
  * - `ids`: an Int32WasmArray or Int32Array of length equal to `x`, containing the index into `levels` for each cell.
  * - `levels`: an array of unique levels, such that `Array.from(ids).map(i => levels[i])` returns the same contents as `x` (aside from invalid values).
+ *   If an input `levels` is supplied, this is returned directly.
  *
  * If `buffer` was supplied, it is used as the value of the `ids` property.
  */
-export function convertToFactor(x, { asWasmArray = true, buffer = null, action = "error", placeholder = -1 } = {}) {
-    let levels = [];
+export function convertToFactor(x, { asWasmArray = true, buffer = null, levels = null, action = "error", placeholder = -1 } = {}) {
     let local_buffer;
 
     let failure;
@@ -67,22 +70,52 @@ export function convertToFactor(x, { asWasmArray = true, buffer = null, action =
         let barr = (asWasmArray ? buffer.array() : buffer); // no allocations from this point onwards!
         let mapping = new Map;
 
-        for (var i = 0; i < x.length; i++) {
-            let y = x[i];
-            if (y == null || (typeof y == "number" && !Number.isFinite(y))) {
-                failure();
-                barr[i] = placeholder;
-                continue;
+        if (levels == null) {
+            levels = [];
+            for (var i = 0; i < x.length; i++) {
+                let y = x[i];
+                if (y == null || (typeof y == "number" && !Number.isFinite(y))) {
+                    failure();
+                    barr[i] = placeholder;
+                    continue;
+                }
+
+                let existing = mapping.get(y);
+                if (typeof existing == "undefined") {
+                    let n = levels.length;
+                    mapping.set(y, n);
+                    levels.push(y);
+                    barr[i] = n;
+                } else {
+                    barr[i] = existing;
+                }
             }
 
-            let existing = mapping.get(y);
-            if (typeof existing == "undefined") {
-                let n = levels.length;
-                mapping.set(y, n);
-                levels.push(y);
-                barr[i] = n;
-            } else {
-                barr[i] = existing;
+            // Sorting them by default, to make life nicer.
+            if (levels.every(x => typeof x == "string")) {
+                let oldlevels = levels.slice();
+                levels.sort();
+                resetLevels({ ids: buffer, levels: oldlevels }, levels);
+            } else if (levels.every(x => typeof x == "number")) {
+                let oldlevels = levels.slice();
+                levels.sort((a, b) => a - b);
+                resetLevels({ ids: buffer, levels: oldlevels }, levels);
+            }
+
+        } else {
+            for (var l = 0; l < levels.length; l++) {
+                mapping.set(levels[l], l);
+            }
+
+            for (var i = 0; i < x.length; i++) {
+                let y = x[i];
+                let existing = mapping.get(y);
+                if (typeof existing == "undefined") {
+                    failure();
+                    barr[i] = placeholder;
+                } else {
+                    barr[i] = existing;
+                }
             }
         }
 
@@ -130,6 +163,70 @@ export function dropUnusedLevels(x) {
     });
 
     return uniq_arr;
+}
+
+/**
+ * Change the levels of a factor, updating the indices appropriately.
+ *
+ * @param {object} x - Factor object produced by {@linkcode convertToFactor}.
+ * @param {Array} newLevels - Array of new levels.
+ * This should be a superset of `x.levels`.
+ * @param {object} [options={}] - Optional parameters.
+ * @param {string} [options.action="error"] - Action to take when `newLevels` is not a superset of `x.levels`.
+ * This can be `"error"`, `"warn"` or `"none"`.
+ * @param {number} [options.placeholder=-1] - Placeholder index to use upon detecting values in `x.levels` that are missing in `newLevels`.
+ * Only used if `action = "warn"` or `"none"`.
+ *
+ * @return `x` is modified by reference such that `x.levels` is set to `newLevels`.
+ * `x.ids` is updated so that the indices now refer to the appropriate value in `newLevels`.
+ */
+export function resetLevels(x, newLevels, { action = "error", placeholder = -1 } = {}) {
+    let mapping = new Map;
+    for (var i = 0; i < newLevels.length; i++) {
+        mapping.set(newLevels[i], i);
+    }
+
+    let failure;
+    if (action == "warn") {
+        let warned = false;
+        failure = () => {
+            if (!warned) {
+                console.warn ("replacing missing levels with the placeholder index '" + String(placeholder) + "'");
+                warned = true;
+            }
+        };
+    } else if (action == "none") {
+        failure = () => {};
+    } else if (action == "error") {
+        failure = () => {
+            throw new Error("detected level in 'x.levels' that is missing from 'newLevels'");
+        };
+    } else {
+        throw new Error("unknown action '" + action + "' for handling missing levels");
+    }
+
+    let oldLevels = x.levels;
+    let conversion = new Array(oldLevels.length);
+    let warned = false;
+    for (var i = 0; i < oldLevels.length; i++) {
+        let found = mapping.get(oldLevels[i]);
+        if (typeof found == "undefined") {
+            failure();
+            conversion[i] = placeholder;
+        } else {
+            conversion[i] = found;
+        }
+    }
+    x.levels = newLevels;
+
+    let target = x.ids;
+    if (target instanceof wa.WasmArray) {
+        // No more wasm allocations past this point!
+        target = target.array();
+    }
+    target.forEach((y, i) => {
+        target[i] = conversion[y];
+    });
 }
 
 /**

--- a/tests/hdf5.test.js
+++ b/tests/hdf5.test.js
@@ -299,8 +299,8 @@ test("HDF5 enum dataset creation and loading works as expected", () => {
         fhandle.writeDataSet("idols", "Enum", [2,3], idols);
 
         let dhandle2 = fhandle.open("idols", { load: true });
-        expect(dhandle2.values).toEqual(new Int32Array([0,1,2,3,1,0]));
-        expect(dhandle2.levels).toEqual(["uzuki", "shizuka", "kaori", "kaede" ]);
+        expect(dhandle2.values).toEqual(new Int32Array([3,2,1,0,2,3]));
+        expect(dhandle2.levels).toEqual(["kaede", "kaori", "shizuka", "uzuki"]);
         expect(dhandle2.shape).toEqual([2, 3]);
     }
 


### PR DESCRIPTION
- Added option to use known levels in convertToFactor, in which case the reported indices are relative to those levels.
- Sort the inferred levels if they are all strings or numbers. This avoids depending on the (arbitrary) order of input values.

The second change is implemented via the new resetLevels function, which updates an existing factor object to use new levels.

Closes #75.